### PR TITLE
Add configurable first-join starter kit

### DIFF
--- a/src/main/java/com/maks/playerdataplugin/DatabaseManager.java
+++ b/src/main/java/com/maks/playerdataplugin/DatabaseManager.java
@@ -74,6 +74,17 @@ public class DatabaseManager {
                 "last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" +
                 ");";
 
+        // Table for storing first join kit contents
+        String firstJoinKitSql = "CREATE TABLE IF NOT EXISTS first_join_kit (" +
+                "id INT PRIMARY KEY," +
+                "contents TEXT" +
+                ");";
+
+        // Table for tracking players who already received the kit
+        String firstJoinPlayersSql = "CREATE TABLE IF NOT EXISTS first_join_players (" +
+                "uuid VARCHAR(36) PRIMARY KEY" +
+                ");";
+
         try (Connection connection = getConnection()) {
             // Create player_data_info table
             try (PreparedStatement statement = connection.prepareStatement(playerDataSql)) {
@@ -85,6 +96,18 @@ public class DatabaseManager {
             try (PreparedStatement statement = connection.prepareStatement(playerStatsSql)) {
                 statement.execute();
                 plugin.getLogger().info("Player stats table created/verified.");
+            }
+
+            // Create first join kit table
+            try (PreparedStatement statement = connection.prepareStatement(firstJoinKitSql)) {
+                statement.execute();
+                plugin.getLogger().info("First join kit table created/verified.");
+            }
+
+            // Create first join players table
+            try (PreparedStatement statement = connection.prepareStatement(firstJoinPlayersSql)) {
+                statement.execute();
+                plugin.getLogger().info("First join players table created/verified.");
             }
         }
     }

--- a/src/main/java/com/maks/playerdataplugin/FirstJoinKitCommand.java
+++ b/src/main/java/com/maks/playerdataplugin/FirstJoinKitCommand.java
@@ -1,0 +1,45 @@
+package com.maks.playerdataplugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Command to open the editor for the first join kit.
+ */
+public class FirstJoinKitCommand implements CommandExecutor {
+
+    private final FirstJoinKitManager kitManager;
+
+    public FirstJoinKitCommand(FirstJoinKitManager kitManager) {
+        this.kitManager = kitManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        if (!player.hasPermission("playerdataplugin.firstjoinkit")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to edit the first join kit.");
+            return true;
+        }
+
+        Inventory inv = Bukkit.createInventory(null, 54, FirstJoinKitManager.INVENTORY_TITLE);
+        ItemStack[] kit = kitManager.loadKit();
+        if (kit != null && kit.length > 0) {
+            inv.setContents(kit);
+        }
+        player.openInventory(inv);
+        player.sendMessage(ChatColor.YELLOW + "Edit the kit and close the inventory to save.");
+        return true;
+    }
+}

--- a/src/main/java/com/maks/playerdataplugin/FirstJoinKitListener.java
+++ b/src/main/java/com/maks/playerdataplugin/FirstJoinKitListener.java
@@ -1,0 +1,26 @@
+package com.maks.playerdataplugin;
+
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+/**
+ * Saves the first join kit when the editor inventory is closed.
+ */
+public class FirstJoinKitListener implements Listener {
+
+    private final FirstJoinKitManager kitManager;
+
+    public FirstJoinKitListener(FirstJoinKitManager kitManager) {
+        this.kitManager = kitManager;
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getView().getTitle().equals(FirstJoinKitManager.INVENTORY_TITLE)) {
+            kitManager.saveKit(event.getInventory().getContents());
+            event.getPlayer().sendMessage(ChatColor.GREEN + "First join kit saved.");
+        }
+    }
+}

--- a/src/main/java/com/maks/playerdataplugin/FirstJoinKitManager.java
+++ b/src/main/java/com/maks/playerdataplugin/FirstJoinKitManager.java
@@ -1,0 +1,86 @@
+package com.maks.playerdataplugin;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.UUID;
+
+/**
+ * Handles storage and distribution of the first join kit.
+ */
+public class FirstJoinKitManager {
+
+    public static final String INVENTORY_TITLE = "First Join Kit Editor";
+
+    private final Main plugin;
+
+    public FirstJoinKitManager(Main plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Load the kit contents from the database.
+     */
+    public ItemStack[] loadKit() {
+        try (Connection conn = plugin.getDatabaseManager().getConnection();
+             PreparedStatement stmt = conn.prepareStatement("SELECT contents FROM first_join_kit WHERE id=1");
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                String data = rs.getString("contents");
+                if (data != null && !data.isEmpty()) {
+                    return SerializationUtils.deserializeItemStackArray(data);
+                }
+            }
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to load first join kit: " + e.getMessage());
+        }
+        return new ItemStack[0];
+    }
+
+    /**
+     * Save the kit contents to the database.
+     */
+    public void saveKit(ItemStack[] items) {
+        String data = SerializationUtils.serializeItemStackArray(items);
+        try (Connection conn = plugin.getDatabaseManager().getConnection();
+             PreparedStatement stmt = conn.prepareStatement("REPLACE INTO first_join_kit (id, contents) VALUES (1, ?)");
+        ) {
+            stmt.setString(1, data);
+            stmt.executeUpdate();
+        } catch (Exception e) {
+            plugin.getLogger().severe("Failed to save first join kit: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Give the kit to a player if they are joining for the first time.
+     */
+    public void giveKitIfFirstJoin(Player player) {
+        UUID uuid = player.getUniqueId();
+        try (Connection conn = plugin.getDatabaseManager().getConnection()) {
+            try (PreparedStatement check = conn.prepareStatement("SELECT 1 FROM first_join_players WHERE uuid=?")) {
+                check.setString(1, uuid.toString());
+                try (ResultSet rs = check.executeQuery()) {
+                    if (rs.next()) {
+                        return; // Already received
+                    }
+                }
+            }
+
+            ItemStack[] kit = loadKit();
+            if (kit != null && kit.length > 0) {
+                player.getInventory().addItem(kit);
+            }
+
+            try (PreparedStatement insert = conn.prepareStatement("INSERT INTO first_join_players (uuid) VALUES (?)")) {
+                insert.setString(1, uuid.toString());
+                insert.executeUpdate();
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("Failed to give first join kit to " + player.getName() + ": " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/maks/playerdataplugin/Main.java
+++ b/src/main/java/com/maks/playerdataplugin/Main.java
@@ -1,9 +1,5 @@
 package com.maks.playerdataplugin;
 
-import com.maks.playerdataplugin.DatabaseManager;
-import com.maks.playerdataplugin.PlayerDataListener;
-import com.maks.playerdataplugin.PlayerStatsManager;
-import com.maks.playerdataplugin.PlayerStatsListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class Main extends JavaPlugin {
@@ -13,6 +9,8 @@ public class Main extends JavaPlugin {
     private PlayerDataListener playerDataListener;
     private PlayerStatsManager playerStatsManager;
     private PlayerStatsListener playerStatsListener;
+    private FirstJoinKitManager firstJoinKitManager;
+    private FirstJoinKitListener firstJoinKitListener;
 
     @Override
     public void onEnable() {
@@ -28,6 +26,9 @@ public class Main extends JavaPlugin {
         databaseManager = new DatabaseManager(this);
         databaseManager.connect();
 
+        // Initialize first join kit manager
+        firstJoinKitManager = new FirstJoinKitManager(this);
+
         // Initialize stats manager
         try {
             playerStatsManager = new PlayerStatsManager(this);
@@ -39,8 +40,11 @@ public class Main extends JavaPlugin {
         }
 
         // Register event listeners
-        playerDataListener = new PlayerDataListener(this);
+        playerDataListener = new PlayerDataListener(this, firstJoinKitManager);
         getServer().getPluginManager().registerEvents(playerDataListener, this);
+
+        firstJoinKitListener = new FirstJoinKitListener(firstJoinKitManager);
+        getServer().getPluginManager().registerEvents(firstJoinKitListener, this);
 
         if (playerStatsManager != null) {
             playerStatsListener = new PlayerStatsListener(this, playerStatsManager);
@@ -51,6 +55,10 @@ public class Main extends JavaPlugin {
             getCommand("stats").setExecutor(statsCommand);
             getCommand("stats").setTabCompleter(statsCommand);
         }
+
+        // Register first join kit command
+        FirstJoinKitCommand firstJoinKitCommand = new FirstJoinKitCommand(firstJoinKitManager);
+        getCommand("firstjoinkit").setExecutor(firstJoinKitCommand);
 
         // Get save interval and batch size from config
         long saveIntervalTicks = getConfig().getLong("saveInterval.ticks", 1200L); // Default: 1 minute (1200 ticks)
@@ -136,5 +144,9 @@ public class Main extends JavaPlugin {
 
     public PlayerStatsManager getPlayerStatsManager() {
         return playerStatsManager;
+    }
+
+    public FirstJoinKitManager getFirstJoinKitManager() {
+        return firstJoinKitManager;
     }
 }

--- a/src/main/java/com/maks/playerdataplugin/PlayerDataListener.java
+++ b/src/main/java/com/maks/playerdataplugin/PlayerDataListener.java
@@ -20,6 +20,7 @@ import java.util.Map;
 public class PlayerDataListener implements Listener {
 
     private final Main plugin;
+    private final FirstJoinKitManager kitManager;
     private final Set<UUID> savingPlayers = ConcurrentHashMap.newKeySet();
     private final Map<UUID, PlayerData> playerDataCache = new HashMap<>();
     private boolean debugMode = false;
@@ -37,8 +38,9 @@ public class PlayerDataListener implements Listener {
         }
     }
 
-    public PlayerDataListener(Main plugin) {
+    public PlayerDataListener(Main plugin, FirstJoinKitManager kitManager) {
         this.plugin = plugin;
+        this.kitManager = kitManager;
         this.debugMode = plugin.getConfig().getBoolean("debug", false);
         this.maxRetryAttempts = plugin.getConfig().getInt("database.maxRetryAttempts", 3);
         this.retryDelayMs = plugin.getConfig().getLong("database.retryDelayMs", 1000);
@@ -165,6 +167,8 @@ public class PlayerDataListener implements Listener {
             plugin.getLogger().severe("Failed to load player data for " + playerName);
             logDebug("Database error while loading data for player " + playerName + ": " + e.getMessage());
         }
+        // Give starter kit if applicable
+        kitManager.giveKitIfFirstJoin(event.getPlayer());
 
         logDebug("Finished loading data for player " + playerName);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,9 @@ commands:
     description: View player statistics
     usage: /<command> [player]
     aliases: [statistics, playerstats]
+  firstjoinkit:
+    description: Edit first join kit
+    usage: /<command>
 
 # Permissions
 permissions:
@@ -36,3 +39,7 @@ permissions:
       playerdataplugin.stats: true
       playerdataplugin.stats.others: true
       playerdataplugin.stats.reload: true
+      playerdataplugin.firstjoinkit: true
+  playerdataplugin.firstjoinkit:
+    description: Allows editing first join kit
+    default: op


### PR DESCRIPTION
## Summary
- add database tables and manager to store a first-join kit and track players who claimed it
- provide `/firstjoinkit` command with GUI editor and automatic saving
- grant kit on first login only

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688cd0f825a8832a973e1cb093d8b7ff